### PR TITLE
Coasting beam calculation for NagaitsevIBS

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -125,15 +125,15 @@ Instantiating BeamParameters from an `xtrack.Line`
 The default mode to instantiate a `BeamParameters` is from an `xpart.Particles` object.
 As seen just above, it is possible to use an `xtrack.Line`'s reference particle to do so.
 
+.. note::
+    Since ``xibs`` version 0.3.0, there is a convenience method to do the above automatically for the user.
+    It is documented in the :ref:`API reference <xibs-inputs>`.
+    It goes according to:
 
-Since ``xibs`` version 0.3.0, there is a convenience method to do the above automatically for the user.
-It is documented in the :ref:`API reference <xibs-inputs>`.
-It goes according to:
+    .. code-block:: python
 
-.. code-block:: python
-
-    # Let's assume your `xtrack.Line` is already defined
-    beam_params = BeamParameters.from_line(line, n_part=5e5)  # need to provide n_part
+        # Let's assume your `xtrack.Line` is already defined
+        beam_params = BeamParameters.from_line(line, n_part=5e5)  # need to provide n_part
 
 
 .. _xibs-faq-beam-params-from-madx:
@@ -177,6 +177,11 @@ It is also possible to query the `beam` in use for the currently active sequence
 Geomettric or Normalized Emittances
 -----------------------------------
 
+.. admonition:: This section in short
+
+    Both can be used, simply set the `normalized_emittances` parameter accordingly when calling functions asking for emittances.
+    Where emittances are returned, the same type as the input ones can be expected.
+
 Some functions in ``xibs`` require emittances to be provided as input, for instance `~xibs.analytical.BjorkenMtingwaIBS.growth_rates`.
 In all such cases, while internally ``xibs`` uses geomtric emittances for computations (as they are the values used in the implemented formulae), it is possible to provide either the geometric or the normalized emittances.
 
@@ -210,16 +215,24 @@ That's as much as the user has to think about this.
 Bunched and Coasting Beams
 --------------------------
 
-Users may want to obtain IBS growth rates for simulations in which they have coasting beams.
-This is possible, through currently only in the Bjorken & Mtingwa formalism.
+.. admonition:: This section in short
 
-The `~.BjorkenMtingwaIBS.growth_rates` method provides a `bunched` boolean argument, which defaults to `True`, corresponding to a bunched beam case.
+    To simulate coasting beams, set `bunched=False` when calling the `.growth_rates` method. Two cases appear:
+
+        - With `~.BjorkenMtingwaIBS` analytical expressions are adapted, leading to correct results.
+        - With `~.NagaitsevIBS` an approximation is made using as bunch length :math:`C / 2 \pi` and a deviation to correct results might be observed. A warning will be logged to the user.
+
+It is possible in ``xibs`` to obtain analytical IBS growth rates for simulations dealing with coasting beams.
+The functionality is implemented in both analytical classes, `~.BjorkenMtingwaIBS` and `~.NagaitsevIBS`, though in the latter an approximation is made and resulting values should be expected to deviate from the correct ones.
+
+The `.growth_rates` in both classes method provides a `bunched` boolean argument, which defaults to `True`, corresponding to a bunched beam case.
 To adapt the growth rates calculation for a coasting beam, one simply has to set this argument to `False`:
 
 .. code-block:: python
 
     # Let's assume your beam and optics parameters have been instantiated
     IBS = xibs.analytical.BjorkenMtingwaIBS(beam_params, optics)
+    # IBS = xibs.analytical.NagaitsevIBS(beam_params, optics)  # alternatively
 
     # Getting growth rates for a bunched beam (default)
     rates_bunched = IBS.growth_rates(psx, epsy, sigma_delta, bunch_length)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,7 +89,7 @@ You can install it simply from with `pip`, from ``PyPI``, in a virtual environme
 
    python -m pip install xibs
 
-.. tip::
+.. hint::
     Don't know what a virtual environment is or how to set it up?
     Here is a good primer on `virtual environments <https://realpython.com/python-virtual-environments-a-primer/>`_ by `RealPython`.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -39,7 +39,7 @@ Integration with xsuite
 The ``xibs`` package is meant to integrate with ``xsuite`` simulations.
 As a first step, all classes encompassing IBS functionality are initialized from the optics of the `xtrack.Line` to simulate for, as well as the `xpart.Particles` distribution to be tracked through the line.
 
-.. tip::
+.. hint::
    
    Please note that while tracking is not necessary to calculate IBS effects (see the Analytical section below), it is necessary to provide an `xpart.Particles` object from which to get required properties.
    The object does not necessarily need to represent a full generated and matched distribution, see the :doc:`FAQ <faq>` for details.

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -67,3 +67,14 @@
 	publisher    = {{American Institute of Physics}},
     year         = 1981,
 }
+
+@proceedings{ICHEA:Piwinski:IntraBeamScattering,
+	author    = {{A Piwinski}},
+    booktitle = {{Proceedings of the 9th International Conference on High-energy Accelerators}},
+	doi       = {10.5170/cern-1992-001.226},
+	url       = {https://cds.cern.ch/record/400720},
+    month     = May,
+	title     = {{Intra-beam-scattering}},
+    venue     = {{SLAC, Stanford, CA, USA}},
+    year      = 1974
+}

--- a/tests/test_analytical/test_raises.py
+++ b/tests/test_analytical/test_raises.py
@@ -34,34 +34,3 @@ def test_analytical_ibs_emittance_evolution_raises_if_no_growth_rates(
         assert (
             "Attempted to compute emittance evolution without having computed growth rates" in record.message
         )
-
-
-def test_nagaitsev_raises_on_coasting_beams(xtrack_ps_injection_protons, caplog):
-    """
-    Checking that NagaitsevIBS.growth_rates raises a NotImplementedError
-    if the user asks for coasting beams, and redirects to BjorkenMtingwaIBS.
-    """
-    # --------------------------------------------------------------------
-    # Load xsuite line (PS here because it's smaller/faster) and init IBS
-    line = xtrack_ps_injection_protons
-    twiss = line.twiss(method="4d")
-    opticsparams = OpticsParameters(twiss)
-    beamparams = BeamParameters(line.particle_ref)
-    beamparams.n_part = int(8.1e8)  # value doesn't matter much
-    IBS = NagaitsevIBS(beamparams, opticsparams)
-    # --------------------------------------------------------------------
-    # Check the error is raised by .growth_rates with bunched=False
-    with pytest.raises(NotImplementedError) as execinfo:
-        IBS.growth_rates(2e-6, 2e-6, 1e-5, 1e-5, bunched=False)  # random values as they don't matter
-    assert "Calculation for coasting beams is not implemented yet in this formalism." in str(execinfo.value)
-    assert "Please use the BjorkenMtignwaIBS class instead, which supports this feature." in str(
-        execinfo.value
-    )
-    # --------------------------------------------------------------------
-    # Check the logged error message
-    for record in caplog.records:
-        assert record.levelname == "ERROR"
-        assert (
-            "Computing growth rates for coasting beams is currently not supported in this class."
-            in record.message
-        )

--- a/xibs/analytical.py
+++ b/xibs/analytical.py
@@ -177,7 +177,7 @@ class AnalyticalIBS(ABC):
         # ----------------------------------------------------------------------------------------------
         # Calculate transverse temperature as 2*P*X, i.e. assume the transverse energy is temperature/2
         # fmt: off
-        Etrans = (  
+        Etrans = (
             5e8
             * (self.beam_parameters.gamma_rel
                * self.beam_parameters.total_energy_eV * 1e-9  # total energy needed in GeV
@@ -523,13 +523,16 @@ class NagaitsevIBS(AnalyticalIBS):
             If these have not been computed yet, this method will first log a message and compute them, then
             compute the growth rates.
 
-        .. note::
+        .. admonition:: Geometric or Normalized Emittances
+
             Both geometric or normalized emittances can be given as input to this function, and it is assumed
             the user provides geomettric emittances. If normalized ones are given the `normalized_emittances`
             parameter should be set to `True` (it defaults to `False`). Internally, a conversion is done to
-            geometric emittances, which are used in the computations.
+            geometric emittances, which are used in the computations. For more information please see the
+            following :ref:`section of the FAQ <xibs-faq-geom-norm-emittances>`.
 
-        .. note::
+        .. admonition:: Coasting Beams
+
             It is possible in this formalism to get an approximation in the case of coasting beams by providing
             `bunched=False`. This will as a bunch length :math:`C / 2 \pi` with C the circumference (or length)
             of the machine, and a warning will be logged for the user. Additionally the appropriate adjustement
@@ -1112,11 +1115,13 @@ class BjorkenMtingwaIBS(AnalyticalIBS):
                 - Defines sub-intervals and integrates the above over all of them, getting growth rates at each element in the lattice.
                 - Averages the results over the full circumference of the machine.
 
-        .. note::
+        .. admonition:: Geometric or Normalized Emittances
+
             Both geometric or normalized emittances can be given as input to this function, and it is assumed
             the user provides geomettric emittances. If normalized ones are given the `normalized_emittances`
             parameter should be set to `True` (it defaults to `False`). Internally, a conversion is done to
-            geometric emittances, which are used in the computations.
+            geometric emittances, which are used in the computations. For more information please see the
+            following :ref:`section of the FAQ <xibs-faq-geom-norm-emittances>`.
 
         Args:
             epsx (float): horizontal geometric or normalized emittance in [m].

--- a/xibs/inputs.py
+++ b/xibs/inputs.py
@@ -313,7 +313,7 @@ def _is_twiss_centered(twiss: "pandas.DataFrame") -> bool:  # noqa: F821
     If the `twiss` was obtained from ``xsuite`` it is never centered and this function
     is not necessary.
 
-    .. tip::
+    .. hint::
         The check is performed as in the Fortran code of the ``IBS`` module in ``MAD-X``.
         We skip all rows in the table until we get to the first element with non-zero length,
         note its `s` position, then the `s` and `l` of the next element. We compare the

--- a/xibs/version.py
+++ b/xibs/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.4.0"
+VERSION = "0.4.1"
 
 
 def version_info() -> str:


### PR DESCRIPTION
Implements the approximation of coasting beams for `NagaitsevIBS` which uses as a bunch length Circumference / (2*pi), and divides the resulting rates by 2. See the ref to Piwinski in the documentation.

This is a patch version as it fixes an incomplete API from the previous release.

Note that this is an approximation and that for exact results one should use `BjorkenMtingwaIBS`, which is logged as a warning to the user.
An FAQ section has been added.